### PR TITLE
Update pm_filter.py

### DIFF
--- a/plugins/pm_filter.py
+++ b/plugins/pm_filter.py
@@ -817,7 +817,7 @@ async def advantage_spell_chok(msg):
     ] for k, movie in enumerate(movielist)]
     btn.append([InlineKeyboardButton(text="Close", callback_data=f'spolling#{user}#close_spellcheck')])
     await msg.reply("I couldn't find anything related to that\nDid you mean any one of these?",
-                    reply_markup=InlineKeyboardMarkup(btn))
+                    reply_markup=InlineKeyboardMarkup(btn), quote=True)
 
 
 


### PR DESCRIPTION
In private chats by default the quote is set to False, And without quoted message the callback query handler for spell_check will fail to retrieve reply_to_message.id and without it, bot will fail to provide file even after guessing the correct movie name. In group chat the default behaviour is True. So I explicitly set quote=True.